### PR TITLE
Add bool to the list of supported simple types

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -333,6 +333,7 @@ fn simple_type_rust_type(
         "int" => ("i32".to_string(), vec![]),
         "string" => ("String".to_string(), vec![]),
         "binary" => ("Vec<u8>".to_string(), vec![]),
+        "boolean" => ("bool".to_string(), vec![]),
         u => panic!("Unknown type: {}", u),
     }
 }

--- a/tests/sample-wadl.xml
+++ b/tests/sample-wadl.xml
@@ -24,6 +24,9 @@
                     <param xmlns:xs="http://www.w3.org/2001/XMLSchema" type="xs:string" style="query" name="password">
                         <doc>The password</doc>
                     </param>
+                    <param xmlns:xs="http://www.w3.org/2001/XMLSchema" type="xs:boolean" style="query" name="eula">
+                        <doc>EULA click through.</doc>
+                    </param>
                     <representation mediaType="application/json"/>
                 </request>
                 <response>


### PR DESCRIPTION
One can very well use xsd:boolean as a type for the field.