### PR TITLE
Improve Rust performance and best practices

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -580,7 +580,7 @@ fn rust_type_for_response(
                     ret.push(param_type);
                 }
                 if ret.len() == 1 {
-                    ret[0].clone()
+                    ret.into_iter().next().unwrap()
                 } else {
                     format!("({})", ret.join(", "))
                 }
@@ -599,7 +599,7 @@ fn rust_type_for_response(
             ret.push(param_type);
         }
         if ret.len() == 1 {
-            ret[0].clone()
+            ret.into_iter().next().unwrap()
         } else {
             format!("({})", ret.join(", "))
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,18 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Reqwest(err) => Some(err),
+            Error::Url(err) => Some(err),
+            Error::Json(err) => Some(err),
+            Error::Wadl(err) => Some(err),
+            Error::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+}
 
 impl From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Self {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -764,7 +764,7 @@ fn parse_method(method_element: &Element) -> Method {
     let request_element = method_element
         .children
         .iter()
-        .find(|node| node.as_element().map_or(false, |e| e.name == "request"))
+        .find(|node| node.as_element().is_some_and(|e| e.name == "request"))
         .and_then(|node| node.as_element());
 
     let request = request_element.map(parse_request).unwrap_or_default();
@@ -772,7 +772,7 @@ fn parse_method(method_element: &Element) -> Method {
     let responses = method_element
         .children
         .iter()
-        .filter(|node| node.as_element().map_or(false, |e| e.name == "response"))
+        .filter(|node| node.as_element().is_some_and(|e| e.name == "response"))
         .map(|node| node.as_element().unwrap())
         .map(parse_response)
         .collect();


### PR DESCRIPTION
- Eliminate unnecessary clones in iterator methods by returning &str instead of String
- Replace HashMap with BTreeMap in Options struct to avoid manual sorting
- Optimize iterator usage by using direct chaining instead of Vec collection
- Enhance error handling with proper source() implementation
- Fix clippy warnings using is_some_and() instead of map_or patterns
- Use derive macros for Default implementation
- Remove redundant Vec indexing with into_iter().next().unwrap()